### PR TITLE
fix(poker): keep short all-ins from reopening action

### DIFF
--- a/environments/Poker/PokerGPU.py
+++ b/environments/Poker/PokerGPU.py
@@ -254,17 +254,21 @@ class PokerGPU(gym.Env):
         ).to(torch.int32)
 
         raise_indices=torch.where(raise_mask)[0]
-        pure_raise_indices=raise_indices[is_raise]
-        new_bets = self.current_round_bet[self.g[pure_raise_indices], self.idx[pure_raise_indices]]
-        old_highest=self.highest[pure_raise_indices].clone()
-        self.highest[pure_raise_indices] = torch.max(self.highest[pure_raise_indices], new_bets)
-        self.agg[pure_raise_indices] = self.idx[pure_raise_indices]
-        self.acted[pure_raise_indices] = 0 # 'new round' of betting on a raise, set acted to 0
-        self.acted[raise_mask] += 1 # increase acted for raisers and callers
-
-        if len(pure_raise_indices) > 0:
+        bet_increase_indices=raise_indices[is_raise]
+        if bet_increase_indices.numel() > 0:
+            new_bets = self.current_round_bet[self.g[bet_increase_indices], self.idx[bet_increase_indices]]
+            old_highest=self.highest[bet_increase_indices].clone()
             actual_raise_sizes = new_bets - old_highest
-            self.last_raise_size[pure_raise_indices] = actual_raise_sizes
+            self.highest[bet_increase_indices] = new_bets
+
+            full_raise_mask = actual_raise_sizes >= self.last_raise_size[bet_increase_indices]
+            full_raise_indices = bet_increase_indices[full_raise_mask]
+            if full_raise_indices.numel() > 0:
+                self.agg[full_raise_indices] = self.idx[full_raise_indices]
+                self.acted[full_raise_indices] = 0 # 'new round' of betting on a full raise, set acted to 0
+                self.last_raise_size[full_raise_indices] = actual_raise_sizes[full_raise_mask]
+
+        self.acted[raise_mask] += 1 # increase acted for raisers and callers
 
     def poker_reward_gpu(self, actions, actor_idx):
         self.s.fill_(0)

--- a/tests/poker/test_poker_gpu_round_progression.py
+++ b/tests/poker/test_poker_gpu_round_progression.py
@@ -16,6 +16,33 @@ def _build_env(n_players: int) -> PokerGPU:
     return env
 
 
+def _configure_raise_state(
+    env: PokerGPU,
+    *,
+    acting_seat: int,
+    previous_aggressor: int,
+    highest: int,
+    acting_bet: int,
+    last_raise_size: int,
+    acting_stack: int,
+    acted: int,
+) -> None:
+    env.idx[0] = torch.tensor(acting_seat, dtype=torch.int32)
+    env.agg[0] = torch.tensor(previous_aggressor, dtype=torch.int32)
+    env.acted[0] = torch.tensor(acted, dtype=torch.int32)
+    env.highest[0] = torch.tensor(highest, dtype=torch.int32)
+    env.last_raise_size[0] = torch.tensor(last_raise_size, dtype=torch.int32)
+    env.current_round_bet[0] = torch.zeros(env.active_players, dtype=torch.int32)
+    env.current_round_bet[0, acting_seat] = torch.tensor(acting_bet, dtype=torch.int32)
+    env.current_round_bet[0, previous_aggressor] = torch.tensor(highest, dtype=torch.int32)
+    env.total_invested[0] = env.current_round_bet[0].clone()
+    env.stacks[0] = torch.full((env.active_players,), 100, dtype=torch.int32)
+    env.stacks[0, acting_seat] = torch.tensor(acting_stack, dtype=torch.int32)
+    env.status[0] = torch.full((env.active_players,), env.ACTIVE, dtype=torch.int32)
+    env.pots[0] = torch.tensor(int(env.total_invested[0].sum().item()), dtype=torch.int32)
+    env.is_done[0] = False
+
+
 def test_step_skips_folded_and_all_in_seats_when_selecting_next_actor():
     env = _build_env(n_players=4)
     env.stacks[0] = torch.tensor([100, 100, 0, 100], dtype=torch.int32)
@@ -127,6 +154,52 @@ def test_step_sets_heads_up_postflop_opener_to_first_active_seat_left_of_button(
     assert env.button[0].item() == 0
     assert env.idx[0].item() == 1
     assert info["seat_idx"][0].item() == 1
+
+
+def test_execute_actions_short_all_in_does_not_reopen_action_or_shrink_min_raise():
+    env = _build_env(n_players=3)
+    _configure_raise_state(
+        env,
+        acting_seat=0,
+        previous_aggressor=2,
+        highest=20,
+        acting_bet=15,
+        last_raise_size=10,
+        acting_stack=8,
+        acted=2,
+    )
+
+    env.execute_actions(torch.tensor([12], dtype=torch.long))
+
+    assert env.current_round_bet[0, 0].item() == 23
+    assert env.highest[0].item() == 23
+    assert env.agg[0].item() == 2
+    assert env.acted[0].item() == 3
+    assert env.last_raise_size[0].item() == 10
+    assert env.status[0, 0].item() == env.ALLIN
+
+
+def test_execute_actions_full_all_in_reopens_action_and_updates_min_raise():
+    env = _build_env(n_players=3)
+    _configure_raise_state(
+        env,
+        acting_seat=0,
+        previous_aggressor=2,
+        highest=20,
+        acting_bet=15,
+        last_raise_size=10,
+        acting_stack=20,
+        acted=2,
+    )
+
+    env.execute_actions(torch.tensor([12], dtype=torch.long))
+
+    assert env.current_round_bet[0, 0].item() == 35
+    assert env.highest[0].item() == 35
+    assert env.agg[0].item() == 0
+    assert env.acted[0].item() == 1
+    assert env.last_raise_size[0].item() == 15
+    assert env.status[0, 0].item() == env.ALLIN
 
 
 def test_step_reward_uses_acting_seat_equity_before_turn_advances():


### PR DESCRIPTION
## Summary

Correct short all-in handling in the GPU betting engine so only full raises reopen action and redefine the minimum raise.

## What Changed

- distinguish bet increases from full raises in `PokerGPU.execute_actions()`
- keep the current aggressor and minimum raise size when an all-in raise is smaller than the required full raise
- add regressions for short all-ins versus full all-in raises

## Files of Interest

- `environments/Poker/PokerGPU.py`
- `tests/poker/test_poker_gpu_round_progression.py`

## How To Test

1. Run `pytest tests/poker/test_poker_gpu_round_progression.py tests/poker/test_poker_gpu_showdown.py -q`.
2. Confirm the new short-all-in regression keeps the prior aggressor and minimum raise size.
3. Confirm the full all-in regression still reopens action and updates the minimum raise size.

## Risks

- This is a rules-level betting change in `execute_actions()`, so any caller that relied on the old short-all-in reopening behavior will now see corrected action flow.

## Linked Issues

- None.
