### PR TITLE
chore(poker): shrink evaluator defaults for fast iteration

### DIFF
--- a/environments/Poker/Player.py
+++ b/environments/Poker/Player.py
@@ -11,6 +11,16 @@ from pathlib import Path
 
 torch.set_float32_matmul_precision('high')
 
+
+def _resolve_weights_path(weights_path) -> Path | None:
+    if weights_path is None:
+        return None
+    normalized = str(weights_path).strip()
+    if not normalized:
+        return None
+    path = Path(normalized)
+    return path if path.is_file() else None
+
 class Player(ABC):
     """
     Stateful object representing a player at the table.
@@ -214,8 +224,9 @@ class PokerQNetwork(nn.Module):
         #    nn.Linear(24, action_dim)
         #)
 
-        if Path(weights_path).exists():
-            model_weights=torch.load(weights_path, map_location=device)
+        resolved_weights_path = _resolve_weights_path(weights_path)
+        if resolved_weights_path is not None:
+            model_weights=torch.load(resolved_weights_path, map_location=device)
             self.network.load_state_dict(model_weights)
 
         self.target_network=copy.deepcopy(self.network)

--- a/scripts/Poker/trainGPU_benchmark.py
+++ b/scripts/Poker/trainGPU_benchmark.py
@@ -16,8 +16,8 @@ import time
 def run_benchmark():
     # Hardcoded configuration
     NUM_PLAYERS = 9
-    N_GAMES = 500000
-    EPISODES = 100
+    N_GAMES = 200
+    EPISODES = 1
     STARTING_BBS = 100
     POKER_ACTION_SPACE_N = 13
     STATE_SPACE = 40

--- a/scripts/Poker/trainGPU_stability.py
+++ b/scripts/Poker/trainGPU_stability.py
@@ -24,8 +24,8 @@ from utils.stability import (
 
 STABILITY_BENCHMARK_DEFAULTS = {
     "NUM_PLAYERS": 9,
-    "N_GAMES": 100000,
-    "EPISODES": 50,
+    "N_GAMES": 200,
+    "EPISODES": 1,
     "STARTING_BBS": 100,
     "POKER_ACTION_SPACE_N": 13,
     "STATE_SPACE": 40,

--- a/tests/poker/test_poker_qnetwork_weight_loading.py
+++ b/tests/poker/test_poker_qnetwork_weight_loading.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+
+from environments.Poker.Player import PokerQNetwork, _resolve_weights_path
+
+
+def _build_q_network(*, weights_path: str | Path) -> PokerQNetwork:
+    return PokerQNetwork(
+        weights_path=weights_path,
+        device=torch.device("cpu"),
+        gamma=0.95,
+        update_freq=20,
+        state_dim=13,
+        action_dim=13,
+        learning_rate=1e-3,
+        weight_decay=0.0,
+    )
+
+
+def test_resolve_weights_path_treats_empty_string_as_missing() -> None:
+    assert _resolve_weights_path("") is None
+    assert _resolve_weights_path("   ") is None
+    assert _resolve_weights_path(None) is None
+
+
+def test_q_network_skips_loading_for_empty_weights_path(monkeypatch) -> None:
+    load_calls: list[Path | str] = []
+
+    def fake_torch_load(path: Path | str, map_location: torch.device) -> dict[str, torch.Tensor]:
+        del map_location
+        load_calls.append(path)
+        raise AssertionError("torch.load should not run for an empty weights path")
+
+    monkeypatch.setattr(torch, "load", fake_torch_load)
+
+    q_network = _build_q_network(weights_path="")
+
+    assert isinstance(q_network, PokerQNetwork)
+    assert load_calls == []
+
+
+def test_q_network_loads_existing_weights_file(tmp_path: Path) -> None:
+    weights_path = tmp_path / "checkpoint.pth"
+    source_network = _build_q_network(weights_path="")
+    expected_state = source_network.network.state_dict()
+    torch.save(expected_state, weights_path)
+
+    loaded_network = _build_q_network(weights_path=weights_path)
+
+    loaded_state = loaded_network.network.state_dict()
+    for key, tensor in expected_state.items():
+        assert torch.equal(loaded_state[key], tensor)


### PR DESCRIPTION
## Summary
Reduce the default poker performance and stability evaluator workloads so they complete quickly in local iteration loops, and make the shared Q-network tolerate an empty checkpoint path so both scripts can start without a preexisting weights file.

## What Changed
- Reduced the hardcoded default workload in `scripts/Poker/trainGPU_benchmark.py` from `500000 x 100` to `200 x 1`.
- Reduced the hardcoded default workload in `scripts/Poker/trainGPU_stability.py` from `100000 x 50` to `200 x 1`.
- Added `_resolve_weights_path` in `environments/Poker/Player.py` so `weights_path=""` is treated as no checkpoint load.
- Added focused regression coverage for empty and existing checkpoint paths in `tests/poker/test_poker_qnetwork_weight_loading.py`.

## Files of Interest
- `scripts/Poker/trainGPU_benchmark.py` - Shrinks default benchmark workload for fast local iterations.
- `scripts/Poker/trainGPU_stability.py` - Shrinks default stability workload for fast local iterations.
- `environments/Poker/Player.py` - Avoids trying to load an empty checkpoint path.
- `tests/poker/test_poker_qnetwork_weight_loading.py` - Covers the checkpoint-path behavior used by the evaluator scripts.

## How To Test
1. Run `pytest tests/poker/test_train_gpu_performance_metrics.py -q`.
2. Run `pytest tests/poker/test_train_gpu_stability_metrics.py -q`.
3. Run `pytest tests/poker/test_poker_qnetwork_weight_loading.py -q`.
4. Run `python -u -m scripts.Poker.trainGPU_benchmark` and confirm it completes quickly with a final steps-per-second line.
5. Run `python -u -m scripts.Poker.trainGPU_stability` and confirm it completes quickly with final stability metrics.

## Risks
The evaluator contract is intentionally weaker after this change: default runs are now smoke-grade rather than statistically rich, so historical scores from the old defaults are no longer directly comparable to new default runs.

## Linked Issues
None.
