### PR TITLE
perf(poker): cache build-actions seat layouts

### DIFF
--- a/environments/Poker/utils.py
+++ b/environments/Poker/utils.py
@@ -4,8 +4,10 @@ import enum
 import eval7
 import torch
 import torch.optim as optim
+from typing import Iterable
 
 _FULL_RANGE = eval7.HandRange("AA,KK,QQ,JJ,TT,99,88,77,66,55,44,33,22,AKs,AKo,AQs,AQo,AJs,AJo,ATs,ATo,A9s,A9o,A8s,A8o,A7s,A7o,A6s,A6o,A5s,A5o,A4s,A4o,A3s,A3o,A2s,A2o,KQs,KQo,KJs,KJo,KTs,KTo,K9s,K9o,K8s,K8o,K7s,K7o,K6s,K6o,K5s,K5o,K4s,K4o,K3s,K3o,K2s,K2o,QJs,QJo,QTs,QTo,Q9s,Q9o,Q8s,Q8o,Q7s,Q7o,Q6s,Q6o,Q5s,Q5o,Q4s,Q4o,Q3s,Q3o,Q2s,Q2o,JTs,JTo,J9s,J9o,J8s,J8o,J7s,J7o,J6s,J6o,J5s,J5o,J4s,J4o,J3s,J3o,J2s,J2o,T9s,T9o,T8s,T8o,T7s,T7o,T6s,T6o,T5s,T5o,T4s,T4o,T3s,T3o,T2s,T2o,98s,98o,97s,97o,96s,96o,95s,95o,94s,94o,93s,93o,92s,92o,87s,87o,86s,86o,85s,85o,84s,84o,83s,83o,82s,82o,76s,76o,75s,75o,74s,74o,73s,73o,72s,72o,65s,65o,64s,64o,63s,63o,62s,62o,54s,54o,53s,53o,52s,52o,43s,43o,42s,42o,32s,32o")
+_GROUPED_AGENT_LAYOUT_CACHE: dict[tuple["PokerAgentType", ...], tuple[tuple[int, "PokerAgentType", tuple[int, ...]], ...]] = {}
 
 def calculate_equity(player_hand, board, stage, num_active_players, player_status):
     # Fast exits for edge cases
@@ -86,6 +88,33 @@ class PokerAgentType(enum.Enum):
     LOOSE_PASSIVE="loose_passive"
     SMALL_BALL="small_ball"
 
+
+def _get_grouped_agent_layout(agent_types: Iterable[PokerAgentType]) -> tuple[tuple[int, PokerAgentType, tuple[int, ...]], ...]:
+    layout_key = tuple(agent_types)
+    cached_layout = _GROUPED_AGENT_LAYOUT_CACHE.get(layout_key)
+    if cached_layout is not None:
+        return cached_layout
+
+    grouped_indices: dict[PokerAgentType, list[int]] = {}
+    first_agent_index: dict[PokerAgentType, int] = {}
+    for agent_idx, agent_type in enumerate(layout_key):
+        grouped_indices.setdefault(agent_type, []).append(agent_idx)
+        first_agent_index.setdefault(agent_type, agent_idx)
+
+    layout = tuple(
+        (first_agent_index[agent_type], agent_type, tuple(seat_indices))
+        for agent_type, seat_indices in grouped_indices.items()
+    )
+    _GROUPED_AGENT_LAYOUT_CACHE[layout_key] = layout
+    return layout
+
+
+def _build_seat_mask(curr_players: torch.Tensor, seat_indices: tuple[int, ...]) -> torch.Tensor:
+    mask = curr_players == seat_indices[0]
+    for seat_idx in seat_indices[1:]:
+        mask |= curr_players == seat_idx
+    return mask
+
 def load_agents(num_players: int, agent_types: list, starting_stack: int, action_space_n: int) -> list:
     # Local imports to avoid circular import with Player -> utils
     from agents.TemperalDifference.PokerQLearning import PokerQLearning
@@ -106,15 +135,10 @@ def load_agents(num_players: int, agent_types: list, starting_stack: int, action
     return players, types
 
 def build_actions(state, actions, curr_players, agents, agent_types, device, epsilon=0.1):
-    grouped_agents = {}
-    for agent_idx, agent_type in enumerate(agent_types):
-        grouped_agents.setdefault(agent_type, []).append(agent_idx)
-
-    for agent_type, seat_indices in grouped_agents.items():
-        mask = torch.zeros_like(curr_players, dtype=torch.bool)
-        for seat_idx in seat_indices:
-            mask |= curr_players == seat_idx
-        agent_idx = seat_indices[0]
+    for agent_idx, agent_type, seat_indices in _get_grouped_agent_layout(agent_types):
+        mask = _build_seat_mask(curr_players, seat_indices)
+        if not mask.any():
+            continue
         if agent_type == PokerAgentType.QLEARNING:
             actions[mask] = agents[agent_idx].get_actions(state[mask])
         elif agent_type == PokerAgentType.RANDOM:

--- a/tests/poker/test_poker_build_actions_layout_cache.py
+++ b/tests/poker/test_poker_build_actions_layout_cache.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import torch
+
+from environments.Poker.utils import (
+    PokerAgentType,
+    _build_seat_mask,
+    _get_grouped_agent_layout,
+    build_actions,
+)
+
+
+class _RecordingAgent:
+    def __init__(self, fill_value: int) -> None:
+        self.fill_value = fill_value
+        self.calls: list[torch.Tensor] = []
+
+    def get_actions(self, states: torch.Tensor) -> torch.Tensor:
+        self.calls.append(states.clone())
+        return torch.full((states.shape[0],), self.fill_value, dtype=torch.long, device=states.device)
+
+    def action(self, states: torch.Tensor) -> torch.Tensor:
+        self.calls.append(states.clone())
+        return torch.full((states.shape[0],), self.fill_value, dtype=torch.long, device=states.device)
+
+
+def test_grouped_agent_layout_is_cached_by_agent_order() -> None:
+    agent_types = [
+        PokerAgentType.QLEARNING,
+        PokerAgentType.RANDOM,
+        PokerAgentType.RANDOM,
+        PokerAgentType.HEURISTIC_HANDS,
+    ]
+
+    first = _get_grouped_agent_layout(agent_types)
+    second = _get_grouped_agent_layout(list(agent_types))
+
+    assert first is second
+    assert first == (
+        (0, PokerAgentType.QLEARNING, (0,)),
+        (1, PokerAgentType.RANDOM, (1, 2)),
+        (3, PokerAgentType.HEURISTIC_HANDS, (3,)),
+    )
+
+
+def test_build_seat_mask_matches_all_requested_seats() -> None:
+    curr_players = torch.tensor([0, 1, 2, 3, 1, 2], dtype=torch.long)
+
+    mask = _build_seat_mask(curr_players, (1, 2))
+
+    assert mask.tolist() == [False, True, True, False, True, True]
+
+
+def test_build_actions_reuses_first_agent_for_shared_types() -> None:
+    q_agent = _RecordingAgent(fill_value=9)
+    random_agent = _RecordingAgent(fill_value=4)
+    heuristic_agent = _RecordingAgent(fill_value=7)
+    agents = [q_agent, random_agent, _RecordingAgent(fill_value=12), heuristic_agent]
+    agent_types = [
+        PokerAgentType.QLEARNING,
+        PokerAgentType.RANDOM,
+        PokerAgentType.RANDOM,
+        PokerAgentType.HEURISTIC_HANDS,
+    ]
+    state = torch.arange(24, dtype=torch.float32).view(6, 4)
+    actions = torch.full((6,), -1, dtype=torch.long)
+    curr_players = torch.tensor([0, 1, 2, 3, 1, 2], dtype=torch.long)
+
+    build_actions(
+        state=state,
+        actions=actions,
+        curr_players=curr_players,
+        agents=agents,
+        agent_types=agent_types,
+        device=torch.device("cpu"),
+    )
+
+    assert q_agent.calls[0].shape[0] == 1
+    assert heuristic_agent.calls[0].shape[0] == 1
+    assert actions[0].item() == 9
+    assert actions[3].item() == 7
+    assert actions[1].item() >= 0
+    assert actions[2].item() >= 0
+    assert actions[4].item() >= 0
+    assert actions[5].item() >= 0


### PR DESCRIPTION
## Summary
Cache the build-actions seat layout so the poker runtime stops rebuilding the same agent-type grouping on every environment step.

## What Changed
- Added a cached grouped-agent layout helper in `environments/Poker/utils.py` keyed by the agent-type order.
- Reused the cached layout inside `build_actions` and skipped empty masks before dispatching actions.
- Added direct tests for the seat-mask helper, the layout cache, and shared-type dispatch behavior.

## Files of Interest
- `environments/Poker/utils.py` - Caches the agent layout used by `build_actions`.
- `tests/poker/test_poker_build_actions_layout_cache.py` - Regression coverage for the new cache behavior.

## How To Test
1. Run `pytest tests/poker/test_poker_build_actions_layout_cache.py -q`.
2. Run `pytest tests/poker/test_heuristic_agents.py -q`.
3. Run `python scripts/Poker/test_poker_gpu_logic_runner.py`.
4. Run `python -u -m scripts.Poker.trainGPU_benchmark` and compare the final steps-per-second line against the current fast-contract baseline.
5. Run `python -u -m scripts.Poker.trainGPU_stability` and confirm the smoke stability metrics still complete without regression.

## Risks
This PR is stacked on top of PR #53 because it depends on the fast evaluator defaults introduced there. The current performance benchmark contract is smoke-grade, so performance deltas are useful for iteration speed but not directly comparable to the old heavyweight defaults.

## Linked Issues
None.
