### PR TITLE
perf(poker): dispatch build-actions by selected indices

### DIFF
--- a/environments/Poker/utils.py
+++ b/environments/Poker/utils.py
@@ -115,6 +115,10 @@ def _build_seat_mask(curr_players: torch.Tensor, seat_indices: tuple[int, ...]) 
         mask |= curr_players == seat_idx
     return mask
 
+
+def _get_selected_indices(curr_players: torch.Tensor, seat_indices: tuple[int, ...]) -> torch.Tensor:
+    return _build_seat_mask(curr_players, seat_indices).nonzero(as_tuple=False).flatten()
+
 def load_agents(num_players: int, agent_types: list, starting_stack: int, action_space_n: int) -> list:
     # Local imports to avoid circular import with Player -> utils
     from agents.TemperalDifference.PokerQLearning import PokerQLearning
@@ -136,15 +140,15 @@ def load_agents(num_players: int, agent_types: list, starting_stack: int, action
 
 def build_actions(state, actions, curr_players, agents, agent_types, device, epsilon=0.1):
     for agent_idx, agent_type, seat_indices in _get_grouped_agent_layout(agent_types):
-        mask = _build_seat_mask(curr_players, seat_indices)
-        if not mask.any():
+        selected_indices = _get_selected_indices(curr_players, seat_indices)
+        if selected_indices.numel() == 0:
             continue
         if agent_type == PokerAgentType.QLEARNING:
-            actions[mask] = agents[agent_idx].get_actions(state[mask])
+            actions[selected_indices] = agents[agent_idx].get_actions(state[selected_indices])
         elif agent_type == PokerAgentType.RANDOM:
-            actions[mask] = torch.randint(0, 13, (curr_players.shape[0],), device=device)[mask]
+            actions[selected_indices] = torch.randint(0, 13, (selected_indices.numel(),), device=device)
         else:
-            actions[mask] = agents[agent_idx].action(state[mask])
+            actions[selected_indices] = agents[agent_idx].action(state[selected_indices])
     
 def load_gpu_agents(device, num_players: int, agent_types: list, starting_stack: int, action_space_n: int) -> list:
     from environments.Poker.Player import HeuristicPlayer, RandomPlayer

--- a/tests/poker/test_poker_build_actions_layout_cache.py
+++ b/tests/poker/test_poker_build_actions_layout_cache.py
@@ -5,6 +5,7 @@ import torch
 from environments.Poker.utils import (
     PokerAgentType,
     _build_seat_mask,
+    _get_selected_indices,
     _get_grouped_agent_layout,
     build_actions,
 )
@@ -49,6 +50,14 @@ def test_build_seat_mask_matches_all_requested_seats() -> None:
     mask = _build_seat_mask(curr_players, (1, 2))
 
     assert mask.tolist() == [False, True, True, False, True, True]
+
+
+def test_get_selected_indices_preserves_actor_order() -> None:
+    curr_players = torch.tensor([3, 1, 2, 1, 0, 2], dtype=torch.long)
+
+    selected_indices = _get_selected_indices(curr_players, (1, 2))
+
+    assert selected_indices.tolist() == [1, 2, 3, 5]
 
 
 def test_build_actions_reuses_first_agent_for_shared_types() -> None:


### PR DESCRIPTION
## Summary
Replace boolean-mask action dispatch with selected-index dispatch so `build_actions` avoids a per-type `mask.any()` sync and stops allocating full-width random tensors for random seats.

## What Changed
- Added `_get_selected_indices` in `environments/Poker/utils.py`.
- Switched `build_actions` to dispatch over selected indices instead of full boolean-mask assignment.
- Added a regression test that preserves the actor order returned by the selected indices helper.

## Files of Interest
- `environments/Poker/utils.py` - Uses selected indices for Q-learning, random, and heuristic action dispatch.
- `tests/poker/test_poker_build_actions_layout_cache.py` - Covers the new selected-index helper.

## How To Test
1. Run `pytest tests/poker/test_poker_build_actions_layout_cache.py -q`.
2. Run `pytest tests/poker/test_heuristic_agents.py -q`.
3. Run `pytest tests/poker/test_train_gpu_performance_metrics.py -q`.
4. Run `python scripts/Poker/test_poker_gpu_logic_runner.py`.
5. Run `python -u -m scripts.Poker.trainGPU_benchmark` and compare against the current baseline from PR #54.
6. Run `python -u -m scripts.Poker.trainGPU_stability` and confirm smoke stability still completes.

## Risks
This PR is stacked on top of PR #54 and still uses the fast evaluator contract introduced by PR #53. Performance numbers are therefore useful for iteration speed within this stack, not for comparison to the original heavyweight evaluator defaults.

## Linked Issues
None.
